### PR TITLE
fix KeyValues syntax errors

### DIFF
--- a/budhud/resource/chatscheme.res
+++ b/budhud/resource/chatscheme.res
@@ -783,4 +783,3 @@ Scheme
 		"2"	"resource/HL2EP2.ttf"		
 	}
 }
-}

--- a/budhud/resource/clientscheme.res
+++ b/budhud/resource/clientscheme.res
@@ -4933,4 +4933,5 @@ Scheme
 			"font" "resource/fonts/Blocks.ttf"
 			"name" "Blocks"
 		}
+	}
 }

--- a/budhud/resource/sourcescheme.res
+++ b/budhud/resource/sourcescheme.res
@@ -17,7 +17,7 @@ Scheme
 			
 		// TF2								
 	    "TFDarkBrown"        							"60 56 53 255"
-	    "TFDarkBrownTranspare							"60 56 53 190"
+	    "TFDarkBrownTransparent"							"60 56 53 190"
 	    "TFTanBright"        							"236 227 203 150"
 	    "TFbh_white"         							"201 188 162 150"
 	    "TFTanMedium"        							"131 121 104 150"
@@ -36,7 +36,7 @@ Scheme
 			
 	    "TFMediumBrown"									"69 64 58 255"
 			
-	    "QuickListBGDeselecte							"69 64 58 255"
+	    "QuickListBGDeselected"							"69 64 58 255"
 	    "QuickListBGSelected"							"131 121 104 150"
 					
 	    "Blank"											"0 0 0 0"
@@ -53,7 +53,7 @@ Scheme
 		// scheme-specific colors			
 		Border.Bright									"200 200 200 196"
 		Border.Dark										"40 40 40 196"
-		Border.Selection								"0 0 0 196"default/selected button
+		Border.Selection								"0 0 0 196"			// default/selected button
 				
 		Button.TextColor								"196 196 196 255"
 		Button.BgColor									"120 120 120 128"
@@ -330,7 +330,6 @@ Scheme
 		}
     }
 
-	}
 	CustomFontFiles
 	{
 		"9"

--- a/budhud/resource/ui/charinfoloadoutsubpanel.res
+++ b/budhud/resource/ui/charinfoloadoutsubpanel.res
@@ -283,8 +283,8 @@
 		"Default"			"0"
 		"font"				"MenuKeys"
 		"scaleImage"		"1"
-		"activeimage"		"..\hud\backpack_01"
-		"inactiveimage"		"..\hud\backpack_01_grey"
+		"activeimage"		"../hud/backpack_01"
+		"inactiveimage"		"../hud/backpack_01_grey"
 		"sound_depressed"	"UI/buttonclick.wav"
 		"sound_released"	"UI/buttonclickrelease.wav"
 	}	

--- a/budhud/resource/ui/econ/ConfirmApplyCardUpgradeApplicationDialog.res
+++ b/budhud/resource/ui/econ/ConfirmApplyCardUpgradeApplicationDialog.res
@@ -47,7 +47,7 @@
     		"enabled"			"1"
 			"pinCorner"			"0"
 			"autoResize"		"0"
-			"PaintBackgroundType""1"
+			"PaintBackgroundType" "1"
 			"border"			"NoBorder"
 			"bgcolor_override"	"35 35 35 255"
 			

--- a/budhud/resource/ui/econ/ConfirmApplyDecodeDialog.res
+++ b/budhud/resource/ui/econ/ConfirmApplyDecodeDialog.res
@@ -47,7 +47,7 @@
     		"enabled"			"1"
 			"pinCorner"			"0"
 			"autoResize"		"0"
-			"PaintBackgroundType""1"
+			"PaintBackgroundType" "1"
 			"border"			"NoBorder"
 			"bgcolor_override"	"35 35 35 255"
 			

--- a/budhud/resource/ui/econ/ConfirmApplyGiftWrapDialog.res
+++ b/budhud/resource/ui/econ/ConfirmApplyGiftWrapDialog.res
@@ -48,7 +48,7 @@
     		"enabled"			"1"
 			"pinCorner"			"0"
 			"autoResize"		"0"
-			"PaintBackgroundType""1"
+			"PaintBackgroundType" "1"
 			"border"			"NoBorder"
 			"bgcolor_override"	"35 35 35 255"
 			

--- a/budhud/resource/ui/econ/ConfirmApplyStrangePartApplicationDialog.res
+++ b/budhud/resource/ui/econ/ConfirmApplyStrangePartApplicationDialog.res
@@ -48,7 +48,7 @@
     		"enabled"			"1"
 			"pinCorner"			"0"
 			"autoResize"		"0"
-			"PaintBackgroundType""1"
+			"PaintBackgroundType" "1"
 			"border"			"NoBorder"
 			"bgcolor_override"	"35 35 35 255"
 			

--- a/budhud/resource/ui/econ/ConfirmApplyTeamColorPaintCanDialog.res
+++ b/budhud/resource/ui/econ/ConfirmApplyTeamColorPaintCanDialog.res
@@ -47,7 +47,7 @@
     		"enabled"			"1"
 			"pinCorner"			"0"
 			"autoResize"		"0"
-			"PaintBackgroundType""1"
+			"PaintBackgroundType" "1"
 			"border"			"NoBorder"
 			"bgcolor_override"	"35 35 35 255"
 			

--- a/budhud/resource/ui/econ/ConfirmCollectDialog.res
+++ b/budhud/resource/ui/econ/ConfirmCollectDialog.res
@@ -47,7 +47,7 @@
     		"enabled"			"1"
 			"pinCorner"			"0"
 			"autoResize"		"0"
-			"PaintBackgroundType""1"
+			"PaintBackgroundType" "1"
 			"border"			"NoBorder"
 			"bgcolor_override"	"35 35 35 255"
 			

--- a/budhud/resource/ui/econ/ConfirmCustomizeTextureDialog.res
+++ b/budhud/resource/ui/econ/ConfirmCustomizeTextureDialog.res
@@ -47,7 +47,7 @@
     		"enabled"			"1"
 			"pinCorner"			"0"
 			"autoResize"		"0"
-			"PaintBackgroundType""1"
+			"PaintBackgroundType" "1"
 			"border"			"NoBorder"
 			"bgcolor_override"	"35 35 35 255"
 			

--- a/budhud/resource/ui/econ/ConfirmItemPreviewDialog.res
+++ b/budhud/resource/ui/econ/ConfirmItemPreviewDialog.res
@@ -47,7 +47,7 @@
     		"enabled"			"1"
 			"pinCorner"			"0"
 			"autoResize"		"0"
-			"PaintBackgroundType""1"
+			"PaintBackgroundType" "1"
 			"border"			"NoBorder"
 			"bgcolor_override"	"35 35 35 255"
 			

--- a/budhud/resource/ui/econ/backpackpanel.res
+++ b/budhud/resource/ui/econ/backpackpanel.res
@@ -366,7 +366,7 @@
     		"enabled"			"1"
 			"pinCorner"			"0"
 			"autoResize"		"0"
-			"PaintBackgroundType""1"
+			"PaintBackgroundType" "1"
 			"border"			"NoBorder"
 			"bgcolor_override"	"35 35 35 255"
 			

--- a/budhud/resource/ui/econ/itemdiscardpanel.res
+++ b/budhud/resource/ui/econ/itemdiscardpanel.res
@@ -66,7 +66,7 @@
     		"enabled"			"1"
 			"pinCorner"			"0"
 			"autoResize"		"0"
-			"PaintBackgroundType""1"
+			"PaintBackgroundType" "1"
 			"border"			"NoBorder"
 			"bgcolor_override"	"35 35 35 255"
 			

--- a/budhud/resource/ui/econ/itempickuppanel.res
+++ b/budhud/resource/ui/econ/itempickuppanel.res
@@ -52,7 +52,7 @@
     		"enabled"			"1"
 			"pinCorner"			"0"
 			"autoResize"		"0"
-			"PaintBackgroundType""1"
+			"PaintBackgroundType" "1"
 			"border"			"NoBorder"
 			"bgcolor_override"	"35 35 35 255"
 			

--- a/budhud/resource/ui/econ/store/v2/storehome_base.res
+++ b/budhud/resource/ui/econ/store/v2/storehome_base.res
@@ -187,7 +187,7 @@
     		"enabled"			"1"
 			"pinCorner"			"0"
 			"autoResize"		"0"
-			"PaintBackgroundType""1"
+			"PaintBackgroundType" "1"
 			"border"			"NoBorder"
 			"bgcolor_override"	"35 35 35 255"
 			

--- a/budhud/resource/ui/econ/store/v2/storepage.res
+++ b/budhud/resource/ui/econ/store/v2/storepage.res
@@ -288,7 +288,7 @@
     		"enabled"			"1"
 			"pinCorner"			"0"
 			"autoResize"		"0"
-			"PaintBackgroundType""1"
+			"PaintBackgroundType" "1"
 			"border"			"NoBorder"
 			"bgcolor_override"	"35 35 35 255"
 			

--- a/budhud/resource/ui/hudobjectivekothtimepanel.res
+++ b/budhud/resource/ui/hudobjectivekothtimepanel.res
@@ -70,7 +70,7 @@
 			"visible"			"1"
 			"enabled"			"1"
 			"delta_item_x" 		"22"
-			"delta_item_start_y""50"
+			"delta_item_start_y" "50"
 			"delta_item_end_y" 	"70"
 			"PositiveColor" 	"0 255 0 255"
 			"NegativeColor" 	"255 0 0 255"

--- a/budhud/resource/ui/mainmenuoverride.res
+++ b/budhud/resource/ui/mainmenuoverride.res
@@ -1622,7 +1622,7 @@
 			"brighttext"					"0"
 			"default"						"1"
 	
-			"sound_depressed"				"ui\quack.wav"
+			"sound_depressed"				"ui/quack.wav"
 			"sound_released"				""
 	
 			"border_default"				""

--- a/budhud/resource/ui/targetid.res
+++ b/budhud/resource/ui/targetid.res
@@ -169,7 +169,7 @@
 		"visible"			"1"
 		"enabled"			"1"	
 		"HealthBonusPosAdj"	"10"
-		"HealthDeathWarning""0.49"
+		"HealthDeathWarning" "0.49"
 		"TFFont"			"HudFontSmall"
 		"HealthDeathWarningColor"	"HUDDeathWarning"
 		"TextColor"			"HudOffWhite"

--- a/budhud/resource/ui/tfadvancedoptionsdialog.res
+++ b/budhud/resource/ui/tfadvancedoptionsdialog.res
@@ -1,4 +1,4 @@
-"Resource\UI\TFAdvancedOptionsDialog.res"
+"Resource/UI/TFAdvancedOptionsDialog.res"
 {
 	"TFAdvancedOptionsDialog"
 	{


### PR DESCRIPTION
I wrote a basic KeyValues linter, and I ran budhud through it as a test. These are the issues I found. After applying these changes, there are no KeyValues errors in the console after starting the game.